### PR TITLE
Make sourcemaps work in development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ pom.xml.asc
 # emacs
 \#*#
 \.\#*
+out/
+resources/public/js/

--- a/project.clj
+++ b/project.clj
@@ -5,20 +5,23 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.5.1"]
                  [org.clojure/core.async "0.1.242.0-44b1e3-alpha"]
-                 [org.clojure/clojurescript "0.0-1909"]
+                 [org.clojure/clojurescript "0.0-2080"]
                  [compojure "1.1.5"]
                  [hiccup "1.0.3"]]
   :source-paths ["src/clj"]
-  :plugins [[lein-cljsbuild "0.3.2"]
+  :plugins [[lein-cljsbuild "1.0.0"]
             [lein-ring "0.8.5"]]
   :ring {:handler snake.core/app}
   :cljsbuild {:builds
               {:dev
                {:source-paths ["src/cljs"]
-                :compiler {:output-to "resources/public/js/dev.js"
-                           :optimizations :whitespace
+                :compiler {:output-dir "resources/public/js"
+                           :output-to "resources/public/js/dev.js"
+                           :source-map true
+                           :source-map-path "js"
+                           :optimizations :none
                            :pretty-print true}}
                :prod
                 {:source-paths ["src/cljs"]
                  :compiler {:output-to "resources/public/js/prod.js"
-                            :optimizations :advanced}}}})          
+                            :optimizations :advanced}}}})

--- a/src/clj/snake/core.clj
+++ b/src/clj/snake/core.clj
@@ -7,16 +7,24 @@
             [clojure.data.json :as json]
             [clojure.string :as string]))
 
+(def js-bootstrap
+  { "dev"  [[:script {:src "js/goog/base.js"}]
+            [:script {:src "js/dev.js"}]
+            [:script "goog.require('snake.core')"]]
+   "prod" [[:script {:src "js/prod.js"}]] })
+
+(defn scripts [env]
+  (conj (js-bootstrap env) [:script "snake.core.init()"]))
+
 (defn page-for [env]
   (html [:head {:title "Snake"}
          [:link {:rel "stylesheet" :href "css/style.css"}]]
-        
-        [:body {:onload "snake.core.init();"}
-         [:div
-          [:div
-           "Level: " [:span {:id "level"} "1"]
-           [:canvas#world {:width 400 :height 400}]
-           [:script {:src  (str "js/" env ".js")}]]]]))
+        [:body
+         (into [:div
+                [:div
+                 "Level: " [:span#level "1"]
+                 [:canvas#world {:width 400 :height 400}]]]
+               (scripts env))]))
 
 (defroutes app-routes
   (GET "/" []


### PR DESCRIPTION
Works for /dev endpoint, in latest versions Chrome.
